### PR TITLE
Use the recommended CA if none are specified

### DIFF
--- a/modules/rds_instance/main.tf
+++ b/modules/rds_instance/main.tf
@@ -9,6 +9,10 @@ locals {
   is_replica = var.replicate_source_db != null
 }
 
+data "aws_rds_certificate" "cert" {
+  latest_valid_till = true
+}
+
 resource "random_id" "snapshot_identifier" {
   count = !var.skip_final_snapshot ? 1 : 0
 
@@ -54,7 +58,7 @@ resource "aws_db_instance" "this" {
   iops                = var.iops
   storage_throughput  = var.storage_throughput
   publicly_accessible = var.publicly_accessible
-  ca_cert_identifier  = var.ca_cert_identifier
+  ca_cert_identifier  = var.ca_cert_identifier == null ? data.aws_rds_certificate.cert.id : var.ca_cert_identifier
 
   allow_major_version_upgrade = var.allow_major_version_upgrade
   auto_minor_version_upgrade  = var.auto_minor_version_upgrade


### PR DESCRIPTION
If var.ca_cert_identifier is not specified, the RDS creation will default to using the CA with id rds-ca-2019
That CA reaches end of life in some months, and AWS has already starting sending emails to database owners that have yet not upgraded. 

The new suggested ID is rds-ca-ecc384-g1, and it can be calculated using the data source used in a PR. 

PLEASE NOTE: If you already created the database, the certifification change will take place IN THE NEXT MAINTENANCE WINDOW unless you also use var. apply_immediately = true