### PR TITLE
Fix repo URL in scaffolding template

### DIFF
--- a/tools/scaffolding/templates/main.tf.template
+++ b/tools/scaffolding/templates/main.tf.template
@@ -15,7 +15,7 @@ provider "aws" {
 
 
 module "db_instance" {
-  source = "git::https://github.com/dfds/aws-modules-rds.git?ref=<release_number>"
+  source = "git::https://github.com/dfds/terraform-aws-rds.git?ref=<release_number>"
 $inputs
 }
 


### PR DESCRIPTION
## Describe your changes
I discovered that I had forgottent to update the new repo URL to the blueprints in the scaffolding template.

## Issue ticket number and link
None

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/qa` folder to apply my changes in QA.
- [x] I have rebased the code to main (or merged in the latest from main)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
