### PR TITLE
Feat/add blueprints tag

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -130,7 +130,7 @@ locals {
     "dfds.env" : var.environment,
     "dfds.cost.centre" : var.cost_centre,
     "dfds.service.availability" : var.service_availability,
-    "dfds.automation.name" : "blueprints"
+    "dfds.automation.name" : "blueprints",
     "dfds.automation.tool" : "Terraform",
     "dfds.automation.initiator.location" : "https://github.com/dfds/terraform-aws-rds",
   }, var.optional_tags, local.resource_owner_contact_email, local.automation_initiator_pipeline_tag)

--- a/locals.tf
+++ b/locals.tf
@@ -130,7 +130,7 @@ locals {
     "dfds.env" : var.environment,
     "dfds.cost.centre" : var.cost_centre,
     "dfds.service.availability" : var.service_availability,
-    "dfds.automation.name" : "blueprints",
+    "dfds.library.name" : "blueprints",
     "dfds.automation.tool" : "Terraform",
     "dfds.automation.initiator.location" : "https://github.com/dfds/terraform-aws-rds",
   }, var.optional_tags, local.resource_owner_contact_email, local.automation_initiator_pipeline_tag)

--- a/locals.tf
+++ b/locals.tf
@@ -130,6 +130,7 @@ locals {
     "dfds.env" : var.environment,
     "dfds.cost.centre" : var.cost_centre,
     "dfds.service.availability" : var.service_availability,
+    "dfds.automation.name" : "blueprints"
     "dfds.automation.tool" : "Terraform",
     "dfds.automation.initiator.location" : "https://github.com/dfds/terraform-aws-rds",
   }, var.optional_tags, local.resource_owner_contact_email, local.automation_initiator_pipeline_tag)


### PR DESCRIPTION
## Describe your changes
This PR adds a dfds.automation.name default tag. This is so that it can be identified as a "blueprint" explicitly rather than implicitly via other tags. This will be useful for identifying deployed "blueprint" resources.

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/qa` folder to apply my changes in QA.
- [x] I have rebased the code to main (or merged in the latest from main)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
