### PR TITLE
Add workflow for creating releases on merge to primary branch

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,27 @@
+name: Auto release on merge
+
+on:
+  push:
+    branches: [master, main]
+    paths-ignore:
+      - .github/**
+      - "**/*.md"
+      - .gitignore
+      - .pre-commit-config.yaml
+      - .tflint.hcl
+      - LICENSE
+      - renovate.json
+      - examples/**
+      - scripts/**
+      - test/**
+
+jobs:
+  auto-release:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: rymndhng/release-on-push-action@master
+        with:
+          bump_version_scheme: patch
+          tag_prefix: ""


### PR DESCRIPTION
## Describe your changes
When a PR is merged to default branch (main), it will auromatically trigger a release based on our semantic labels. 
Unless it is only ignored paths that were updated.

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/2505

## Checklist before requesting a review
- [x] I have rebased the code to main (or merged in the latest from main)


## Is it a new release?
- [x] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
