### PR TITLE
Chore/tf-version-lock-cleanup-output

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Terraform module for AWS RDS instances
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0, < 2.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0, < 1.6.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1 |
 
@@ -126,7 +126,6 @@ Terraform module for AWS RDS instances
 |------|-------------|
 | <a name="output_iam_instance_profile_for_ec2"></a> [iam\_instance\_profile\_for\_ec2](#output\_iam\_instance\_profile\_for\_ec2) | The name of the EC2 instance profile that is using the IAM Role that give AWS services access to the RDS instance and Secrets Manager |
 | <a name="output_iam_role_arn_for_aws_services"></a> [iam\_role\_arn\_for\_aws\_services](#output\_iam\_role\_arn\_for\_aws\_services) | The ARN of the IAM Role that give AWS services access to the RDS instance and Secrets Manager |
-| <a name="output_instance_engine_info"></a> [instance\_engine\_info](#output\_instance\_engine\_info) | The engine info for the selected engine of the RDS instance |
 | <a name="output_kubernetes_serviceaccount"></a> [kubernetes\_serviceaccount](#output\_kubernetes\_serviceaccount) | If you create this Kubernetes ServiceAccount, you will get access to the RDS through IRSA |
 | <a name="output_peering"></a> [peering](#output\_peering) | n/a |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,13 +1,3 @@
-# output "db_instance_master_user_secret_arn" {
-#   description = "The ARN of the master user secret (Only available when manage_master_user_password is set to true)"
-#   value       = module.db[0].db_instance_master_user_secret_arn
-# }
-
-# output "db_cluster_master_user_secret_arn" {
-#   description = "The ARN of the master user secret (Only available when manage_master_user_password is set to true)"
-#   value       = module.cluster[0].cluster_master_user_secret_arn
-# }
-
 output "kubernetes_serviceaccount" {
   description = "If you create this Kubernetes ServiceAccount, you will get access to the RDS through IRSA"
   value = try(<<EOT
@@ -32,9 +22,4 @@ output "iam_role_arn_for_aws_services" {
 output "iam_instance_profile_for_ec2" {
   description = "The name of the EC2 instance profile that is using the IAM Role that give AWS services access to the RDS instance and Secrets Manager"
   value       = try(module.db_instance[0].iam_instance_profile_for_ec2, null)
-}
-
-output "instance_engine_info" {
-  description = "The engine info for the selected engine of the RDS instance"
-  value       = jsonencode(data.aws_rds_engine_version.engine_info)
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0, < 2.0.0"
+  required_version = ">= 1.3.0, < 1.6.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
## Describe your changes
- Uppen version limit modified in response to license on Terraform imposed by HashiCorp
- Removed unusued outputs

## Issue ticket number and link
https://github.com/dfds/cloudplatform/issues/2518

## Checklist before requesting a review
- [x] I have tested changes in my sandbox
- [] I have added the needed changes in the `test/qa` folder to apply my changes in QA.
- [ ] I have rebased the code to main (or merged in the latest from main)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
