### PR TITLE
fix: remove empty backend s3 block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-terraform {
-  backend "s3" {}
-}
-
 resource "random_id" "snapshot_identifier" {
   count = !var.skip_final_snapshot ? 1 : 0
 


### PR DESCRIPTION
## Describe your changes
This PR will remove the empty s3 backend block which is unnecessary for terraform and blocks terragrunt from working with the suggested generate backend - https://terragrunt.gruntwork.io/docs/features/keep-your-remote-state-configuration-dry/

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/qa` folder to apply my changes in QA.
- [ ] I have rebased the code to main (or merged in the latest from main)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
