### PR TITLE
Add labels to lock file PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,9 +3,6 @@
   "extends": [
     "local>dfds/renovate-config"
   ],
-  "schedule": [
-    "after 6am and before 8am on tuesday"
-  ],
   "terraform": {
     "managerFilePatterns": [
       "/\\.tf$/",
@@ -14,11 +11,22 @@
   },
   "packageRules": [
     {
+        "matchUpdateTypes": [
+            "lockFileMaintenance"
+        ],
+        "addLabels": [
+            "lockFile",
+            "on-hold"
+        ],
+        "minimumReleaseAge": null,
+        "automerge": false,
+        "matchCurrentVersion": "!/^0/"
+    },
+    {
       "matchUpdateTypes": [
         "pin",
         "digest",
-        "patch",
-        "lockFileMaintenance"
+        "patch"
       ],
       "addLabels": [
         "release:patch"


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to refine how Renovate handles dependency updates, especially for lock file maintenance and patch updates. The main changes involve removing the scheduled update window, introducing a new rule for lock file maintenance, and adjusting labeling and automerge behaviors.

**Renovate configuration improvements:**

* Removed the scheduled update window, so Renovate is no longer restricted to running between 6am and 8am on Tuesdays.
* Added a new package rule targeting `lockFileMaintenance` updates to:
  * Add the `lockFile` and `on-hold` labels,
  * Prevent automerging,
  * Remove minimum release age restrictions,
  * Only match current versions not starting with `0`.
* Updated the existing package rule for `pin`, `digest`, and `patch` updates to no longer include `lockFileMaintenance` updates, ensuring clearer separation of update types and their handling.