### PR TITLE
marked mise config as norelease with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -58,7 +58,9 @@
       "description": "Group dependencies affecting the QA environment.",
       "additionalBranchPrefix": "qa/",
       "matchFileNames": [
-        "tests/qa/**"
+        "tests/qa/**",
+        ".github/**",
+        "mise.toml"
       ],
       "addLabels": [
         "norelease"


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
This pull request makes sure that fx terragrunt version updates and other tooling updates does not result a new release and cause a new chain of PRs that depends on it. Example https://github.com/dfds/terraform-aws-rds/pull/362

- The `qa` dependency group in `renovate.json` now also includes `.github/**` and `mise.toml` files, in addition to the existing `tests/qa/**` pattern.
## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/qa` folder to apply my changes in QA.
- [ ] I have rebased the code to main (or merged in the latest from main)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
