### PR TITLE
renovate config fix norelease label

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -66,6 +66,7 @@
       "description": "Group dependencies affecting the QA environment.",
       "matchFileNames": [
         "tests/qa/**",
+        "scripts/qa/**",
         ".github/**",
         "mise.toml"
       ],


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
This pull request updates the `renovate.json` configuration to fix labelling on tooling updates so we don't get double labels (only noreleae label should be applied).

Configuration improvements for QA dependencies:

* Added the `norelease` label and enabled `automerge` for the group of dependencies affecting the QA environment, ensuring that these updates are automatically merged without triggering a release. (`renovate.json`)
## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/qa` folder to apply my changes in QA.
- [ ] I have rebased the code to main (or merged in the latest from main)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
