### PR TITLE
Fix the way shared workflows are used

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -2,7 +2,7 @@ name: Auto release on merge
 
 on:
   push:
-    branches: [master, main]
+    branches: [main]
     paths-ignore:
       - .github/**
       - "**/*.md"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -17,19 +17,15 @@ on:
 
 jobs:
   auto-release:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - id: release
-        uses: rymndhng/release-on-push-action@master
-        with:
-          bump_version_scheme: patch
-          tag_prefix: ""
+    uses: dfds/shared-workflows/.github/workflows/automation-auto-release.yml@v2.0.1
 
+  dispatch-blueprints:
+    needs: auto-release
+    runs-on: ubuntu-latest
+    steps:
       - name: Dispatch to blueprints
         run: |
           curl -X POST https://api.github.com/repos/dfds/infrastructure-blueprints/dispatches \
           -H 'Accept: application/vnd.github.everest-preview+json' \
           -u ${{ secrets.AUTH_TOKEN }} \
-          --data '{"event_type": "trigger-rds-workflow", "client_payload": { "release_tag": "${{ steps.release.outputs.tag_name }}" }}'
+          --data '{"event_type": "trigger-rds-workflow", "client_payload": { "release_tag": "${{ needs.auto-release.outputs.tag_name }}" }}'

--- a/.github/workflows/block-on-hold-prs.yml
+++ b/.github/workflows/block-on-hold-prs.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   shared:
-    uses: dfds/shared-workflows/.github/workflows/automation-on-hold-prs.yml@master
+    uses: dfds/shared-workflows/.github/workflows/automation-on-hold-prs.yml@v2.0.1

--- a/.github/workflows/block-on-hold-prs.yml
+++ b/.github/workflows/block-on-hold-prs.yml
@@ -2,7 +2,7 @@ name: Block on-hold PRs
 
 on:
   pull_request:
-    branches: [ master, main ]
+    branches: [main]
     types: [ opened, labeled, unlabeled, synchronize ]
 
 jobs:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,6 +1,7 @@
 name: Generate terraform docs
 on:
-  - pull_request
+  pull_request:
+    branches: [main]
 
 jobs:
   docs:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,10 +11,9 @@ jobs:
         ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Render terraform docs and push changes back to PR
-      uses: terraform-docs/gh-actions@main
+      uses: terraform-docs/gh-actions@v1.4.1
       with:
         working-dir: .
         output-file: README.md
         output-method: inject
         git-push: "true"
-        tf_docs_git_push: 'true'

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -6,9 +6,4 @@ on:
     branches: [main]
 jobs:
   enforce-label:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: yogevbd/enforce-label-action@2.2.2
-      with:
-        REQUIRED_LABELS_ANY: "release:minor,release:major,release:patch,norelease"
-        REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label ['release:minor','release:major','release:patch', 'norelease']"
+    uses: dfds/shared-workflows/.github/workflows/automation-enforce-release-labels.yml@v2.0.1

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   shared:
-    uses: dfds/shared-workflows/.github/workflows/automation-housekeeping.yml@master
+    uses: dfds/shared-workflows/.github/workflows/automation-housekeeping.yml@v2.0.1
     secrets: inherit
     with:
       delete_head_branch: true

--- a/.github/workflows/qa-down.yml
+++ b/.github/workflows/qa-down.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Send alert if job fails
         if: failure()
-        uses: dfds/shared-workflows/.github/actions/automation-slack-notifier@master
+        uses: dfds/shared-workflows/.github/actions/automation-slack-notifier@v2.0.1
         with:
           slack_webhook: ${{ env.SLACK_WEBHOOK }}
           slack_message: Teardown QA environment for RDS failed.

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Send alert if job fails
         if: failure()
-        uses: dfds/shared-workflows/.github/actions/automation-slack-notifier@master
+        uses: dfds/shared-workflows/.github/actions/automation-slack-notifier@v2.0.1
         with:
           slack_webhook: ${{ env.SLACK_WEBHOOK }}
           slack_message: Spin up QA environment for RDS failed.
@@ -112,7 +112,7 @@ jobs:
 
       - name: Send alert if job fails
         if: failure()
-        uses: dfds/shared-workflows/.github/actions/automation-slack-notifier@master
+        uses: dfds/shared-workflows/.github/actions/automation-slack-notifier@v2.0.1
         with:
           slack_webhook: ${{ env.SLACK_WEBHOOK }}
           slack_message: Test QA environment for RDS failed.

--- a/.github/workflows/secret-detection.yml
+++ b/.github/workflows/secret-detection.yml
@@ -2,9 +2,9 @@ name: Gitleaks Manual
 
 on:
   push:
-    branches: [ "master", "main" ]
+    branches: [main]
   pull_request:
-    branches: [ "master", "main" ]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,9 +1,9 @@
 name: Run Trivy IAC
 on:
   push:
-    branches: ["master", "main"]
+    branches: [main]
   pull_request:
-    branches: ["master", "main"]
+    branches: [main]
   workflow_dispatch:
 jobs:
   shared:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -7,4 +7,4 @@ on:
   workflow_dispatch:
 jobs:
   shared:
-    uses: dfds/shared-workflows/.github/workflows/security-trivy-iac-check.yaml@master
+    uses: dfds/shared-workflows/.github/workflows/security-trivy-iac-check.yaml@v2.0.1


### PR DESCRIPTION
- **refactor: streamline auto-release workflow and update dispatch payload**
- **chore: update automation-on-hold-prs workflow to version 2.0.1**
- **fix: pin terraform-docs action to v1.4.1 for stability**
- **chore: update enforce-labels workflow to use shared automation for label enforcement**
- **chore: update housekeeping workflow to use version 2.0.1 of shared automation**
- **fix: pin automation-slack-notifier action to v2.0.1 for stability**
- **fix: pin automation-slack-notifier action to v2.0.1 for stability**
- **fix: pin security-trivy-iac-check workflow to version v2.0.1 for stability**
- **fix: update branch references from master to main in workflow files**

## Describe your changes
<!--Describe the change here-->

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/qa` folder to apply my changes in QA.
- [ ] I have rebased the code to main (or merged in the latest from main)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
