### PR TITLE
fix: support log connections v18

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -3,7 +3,7 @@ locals {
   ########################################################################
   # Parameter group
   ########################################################################
-  pg_major_version          = tonumber(split(".", local.engine_version)[0])
+  pg_major_version                = tonumber(split(".", local.engine_version)[0])
   create_db_parameter_group       = true
   parameter_group_family          = data.aws_rds_engine_version.engine_info.parameter_group_family
   parameter_group_use_name_prefix = true

--- a/locals.tf
+++ b/locals.tf
@@ -3,13 +3,14 @@ locals {
   ########################################################################
   # Parameter group
   ########################################################################
+  pg_major_version          = tonumber(split(".", local.engine_version)[0])
   create_db_parameter_group       = true
   parameter_group_family          = data.aws_rds_engine_version.engine_info.parameter_group_family
   parameter_group_use_name_prefix = true
   prod_instance_parameters = var.environment == "prod" ? [
     {
       name         = "log_connections"
-      value        = 1
+      value        = local.pg_major_version >= 18 ? "all" : "1"
       apply_method = "immediate"
     }
   ] : []


### PR DESCRIPTION
## Describe your changes
This PR fixes an issue when upgrading to engine_version 18 caused by an AWS change for granular log_connections

To test this PR - deploy a postgres instance with `environment = "prod"` and `engine_version = "17"`.

Then modify the terraform to `engine_version = "18"` and add `apply_immediately = true`. You should observe that the database upgrades successfully whereas previously it would give errors

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have tested changes in my sandbox
- [ ] I have added the needed changes in the `test/qa` folder to apply my changes in QA.
- [ ] I have rebased the code to main (or merged in the latest from main)


## Is it a new release?
- [ ] Apply a release tag `release:(major|minor|patch)`, following semantic versioning in [this guide](https://semver.org/) or `norelease` if there is no changes to the Terraform code
